### PR TITLE
Fix the Node 0.12 Fatal error

### DIFF
--- a/tasks/yui-compressor.js
+++ b/tasks/yui-compressor.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
 		var length = files.length;
 		var count = 0;
 		var options = this.options({
-			'report': 'gzip'
+			'report': 'min'
 		});
 		files.forEach(function(file) {
 			yuiCompressor({


### PR DESCRIPTION
When updating to Node 0.12 there is an error "Fatal Error: Cannot assign to read only property 'subarray'". This is because of the report option set to gzip. This change is to set the value to min (the original default). This will fix the issue.